### PR TITLE
docs: add Context7 AI chat widget to docs site

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,6 +5,17 @@ export default defineConfig({
   description: 'Decorator-based entity seeding for TypeORM and MikroORM',
   base: '/seeders/',
 
+  head: [
+    [
+      'script',
+      {
+        src: 'https://context7.com/widget.js',
+        'data-library': '/llmstxt/joakimbugge_github_io_seeders_llms_txt',
+        'data-color': '#3451b2',
+      },
+    ],
+  ],
+
   themeConfig: {
     nav: [
       {


### PR DESCRIPTION
Loads the Context7 floating chat assistant on every VitePress page via the head config, themed to match the site brand color (#3451b2).