### PR TITLE
chore: pin packageManager to npm 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "packageManager": "npm@11.13.0",
+  "packageManager": "npm@12.0.2",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
Follow-up to #109. Local and CI now both run npm 12.0.2, so the field can state the version this repo is actually developed and released with instead of trailing it.

npm 12 requires Node `^22.22.2 || ^24.15.0 || >=26.0.0` — worth knowing before Corepack enforces this on anyone's machine.

Verified locally on Node 24.19.0 with npm 12.0.2: `npm install` runs every allowed install script (`better_sqlite3.node` present), `npm install-scripts ls` reports nothing unreviewed, the full test suite passes, and the lefthook pre-commit hook runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)