### PR TITLE
test(mikroorm): give loadOrm's dynamic-import test room on a cold cache

### DIFF
--- a/packages/mikroorm-seeder/tests/utils/loadOrm.test.ts
+++ b/packages/mikroorm-seeder/tests/utils/loadOrm.test.ts
@@ -33,11 +33,17 @@ describe('loadOrm()', () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('No MikroORM instance found'));
   });
 
+  // loadOrm() imports the fixture at runtime, which is the whole point of this test, so the
+  // first-touch cost of the @mikro-orm graph and better-sqlite3 lands inside the test body and
+  // counts against testTimeout. Every other test in this package reaches that graph through a
+  // static import instead, where the cost falls in the untimed collect phase. On a cold file
+  // cache — a fresh install, or CI right after `npm ci` — that import alone has exceeded the 5s
+  // default, so this test gets explicit headroom.
   it('resolves a MikroORM instance from an explicit path', async () => {
     const orm = await loadOrm(ormPath);
 
     expect(typeof orm.close).toBe('function');
 
     await orm.close();
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
Fixes the only flaky test in the repo. `loadOrm() > resolves a MikroORM instance from an explicit path` timed out at the 5s default three separate times today, always on the first run after an install, always passing on the immediate re-run.

## Why only this test

The cause is structural, not environmental:

| | How the `@mikro-orm` graph is reached | Budget |
|---|---|---|
| `loadOrm.test.ts` (this test) | runtime dynamic `import()` **inside the test body** | `testTimeout` — **5s** |
| 9 other test files | static `import` at module top level | collect phase — **untimed** |
| tests calling `MikroORM.init()` | inside `beforeEach` | `hookTimeout` — 10s |

`loadOrm()` importing a file at runtime *is* the behaviour under test, so the first-touch cost of `@mikro-orm/core`, `/sqlite`, `/decorators/legacy` and `better-sqlite3` is unavoidably paid inside the test body. Everywhere else that cost lands in a phase vitest never times out. That asymmetry is the entire explanation for why one test out of 80 flakes.

The cost cannot be moved to a static import without defeating the test's purpose, so the test gets an explicit 30s budget. Warm, it finishes in ~400ms, so the margin is generous without masking a real hang.

## Verification

Isolated cold runs were not enough to reproduce — clearing only the vite cache still passed in 371–430ms. The condition that actually reproduces it is freshly *written* dependency files, i.e. a cold OS page cache (and on Windows, Defender scanning each file on first read).

Reproduced that deliberately: deleted `node_modules/@mikro-orm`, `node_modules/better-sqlite3` and both vite transform caches, reinstalled so the files were written fresh, then ran the full monorepo suite.

Result: **green**, with `mikroorm-seeder`'s aggregate import time elevated to **24.25s** — the same signature as the run that failed, which reported **55.90s**. That is the mechanism, directly observed.

## Honest caveat

The >5s case depends on filesystem and antivirus timing, so it cannot be reproduced deterministically on demand. What is certain: three observed failures all exceeded 5s on that single test, its warm cost is ~400ms, and 30s leaves a 75× margin. CI does `npm ci` before every run, so it has always been exposed to this too — it has simply been fast enough on Linux runners.

`packages/typeorm-seeder/tests/utils/loadDataSource.test.ts` has the same shape and has never flaked, TypeORM's graph being far smaller. Left alone deliberately rather than pre-emptively padded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)